### PR TITLE
Fixed Expand-Archive params

### DIFF
--- a/scripts/lis_hyperv_platform/lisa_run.ps1
+++ b/scripts/lis_hyperv_platform/lisa_run.ps1
@@ -54,7 +54,7 @@ function Main {
         if ($LastExitCode){
             throw "Failed to download Putty binaries"
         }
-        Expand-Archive .\PuttyBinaries.zip -DestinationPath ".\lis-test\WS2012R2\lisa\bin"
+        Expand-Archive ".\PuttyBinaries.zip" ".\lis-test\WS2012R2\lisa\bin"
     }
     
     ($KeyName, $XmlName) = Get-Dependencies $KeyPath $XmlTest


### PR DESCRIPTION
On some PS versions: Expand-Archive -InputObject <PSObject> [[-OutputPath] <String>]
[-EntryPath <String[]>

On some PS versions: Expand-Archive [-Path] <String> [[-DestinationPath]