### PR TITLE
Removed kernel dirty tag

### DIFF
--- a/scripts/package_building/build_artifacts.sh
+++ b/scripts/package_building/build_artifacts.sh
@@ -431,7 +431,7 @@ function build_debian (){
     fi
     if [[ "$build_state" == "kernel" ]];then
         pushd "$source"
-        fakeroot make-kpkg --initrd -j"$thread_number" kernel_image kernel_headers kernel_source kernel_debug
+        make-kpkg --rootcmd fakeroot --initrd -j"$thread_number" kernel_image kernel_headers kernel_source kernel_debug
         popd
     elif [[ "$build_state" == "daemons" ]];then
         pushd "${base_dir}/daemons/hyperv-daemons"


### PR DESCRIPTION
Specify to the make-kpkg the rootcmd flag to fakeroot and not run
make-kpkg inside fakeroot.
Bug fix link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717807