### PR TITLE
Always force a git checkout to master

### DIFF
--- a/scripts/package_building/build_artifacts.sh
+++ b/scripts/package_building/build_artifacts.sh
@@ -125,7 +125,10 @@ function get_sources_git (){
     pushd "$source"
     git reset --hard > /dev/null
     git fetch > /dev/null
-    git checkout "$git_branch" > /dev/null
+    # Note(avladu): the checkout to master is needed to
+    # get from a detached HEAD state
+    git checkout master > /dev/null
+    git checkout -f "$git_branch" > /dev/null
     git pull > /dev/null
     popd
     popd


### PR DESCRIPTION
This step is needed in case the repo is in a detached head state.
If the repo is in a detached head state, the checkout to another
branch and the subsequent git pull is not correctly performed.