### PR TITLE
[jenkinsfile] Build name changed for msft, upstream and dev pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,12 @@ pipeline {
                     writeFile file: 'ARM_OSVHD_NAME.azure.env', text: "SS-AUTOBUILT-Canonical-UbuntuServer-16.04-LTS-latest-${BUILD_NAME}${BUILD_NUMBER}.vhd"
                     writeFile file: 'KERNEL_PACKAGE_NAME.azure.env', text: 'testKernel.deb'
                 }
+                sh '''#!/bin/bash
+                  echo ${BUILD_NUMBER}-$(crudini --get scripts/package_building/kernel_versions.ini KERNEL_BUILT folder) > ./build_name
+                '''
+                script {
+                  currentBuild.displayName = readFile "./build_name"
+                }
                 stash includes: '*.azure.env', name: 'azure.env'
                 stash includes: 'scripts/package_building/kernel_versions.ini', name: 'kernel_version_ini'
                 stash includes: ("scripts/package_building/${env.BUILD_NUMBER}-${env.BRANCH_NAME}-${env.KERNEL_ARTIFACTS_PATH}/msft*/deb/**"),
@@ -119,6 +125,12 @@ pipeline {
                     writeFile file: 'ARM_IMAGE_NAME.azure.env', text: 'OpenLogic CentOS 7.3 latest'
                     writeFile file: 'ARM_OSVHD_NAME.azure.env', text: "SS-AUTOBUILT-OpenLogic-CentOS-7.3-latest-${BUILD_NAME}${BUILD_NUMBER}.vhd"
                     writeFile file: 'KERNEL_PACKAGE_NAME.azure.env', text: 'testKernel.rpm'
+                }
+                sh '''#!/bin/bash
+                  echo ${BUILD_NUMBER}-$(crudini --get scripts/package_building/kernel_versions.ini KERNEL_BUILT folder) > ./build_name
+                '''
+                script {
+                  currentBuild.displayName = readFile "./build_name"
                 }
                 stash includes: '*.azure.env', name: 'azure.env'
                 stash includes: 'scripts/package_building/kernel_versions.ini', name: 'kernel_version_ini'

--- a/linux_pipeline/Jenkinsfile_developer_patch_validation
+++ b/linux_pipeline/Jenkinsfile_developer_patch_validation
@@ -92,6 +92,12 @@ pipeline {
                           popd
                           '''
                 }
+                sh '''#!/bin/bash
+                  echo ${BUILD_NUMBER}-$(crudini --get scripts/package_building/kernel_versions.ini KERNEL_BUILT folder) > ./build_name
+                '''
+                script {
+                  currentBuild.displayName = readFile "./build_name"
+                }
                 stash includes: 'scripts/package_building/kernel_versions.ini', name: 'kernel_version_ini'
                 stash includes: ("scripts/package_building/${env.BUILD_NUMBER}-${env.BRANCH_NAME}-${env.KERNEL_ARTIFACTS_PATH}/**/deb/**"),
                 name: "${env.KERNEL_ARTIFACTS_PATH}"

--- a/linux_pipeline/Jenkinsfile_upstream_kernel
+++ b/linux_pipeline/Jenkinsfile_upstream_kernel
@@ -76,6 +76,12 @@ pipeline {
                     --create_changelog "${CREATE_CHANGELOG}"
                 popd
                 '''
+                sh '''#!/bin/bash
+                  echo ${BUILD_NUMBER}-$(crudini --get scripts/package_building/kernel_versions.ini KERNEL_BUILT folder) > ./build_name
+                '''
+                script {
+                  currentBuild.displayName = readFile "./build_name"
+                }
                 writeFile file: 'ARM_IMAGE_NAME.azure.env', text: 'Canonical UbuntuServer 16.04-LTS latest'
                 writeFile file: 'ARM_OSVHD_NAME.azure.env', text: "SS-AUTOBUILT-Canonical-UbuntuServer-16.04-LTS-latest-${BUILD_NAME}${BUILD_NUMBER}.vhd"
                 writeFile file: 'KERNEL_PACKAGE_NAME.azure.env', text: 'testKernel.deb'
@@ -122,6 +128,12 @@ pipeline {
                     --build_date="${TIMESTAMP}"
                 popd
                 '''
+                sh '''#!/bin/bash
+                  echo ${BUILD_NUMBER}-$(crudini --get scripts/package_building/kernel_versions.ini KERNEL_BUILT folder) > ./build_name
+                '''
+                script {
+                  currentBuild.displayName = readFile "./build_name"
+                }
                 writeFile file: 'ARM_IMAGE_NAME.azure.env', text: 'OpenLogic CentOS 7.3 latest'
                 writeFile file: 'ARM_OSVHD_NAME.azure.env', text: "SS-AUTOBUILT-OpenLogic-CentOS-7.3-latest-${BUILD_NAME}${BUILD_NUMBER}.vhd"
                 writeFile file: 'KERNEL_PACKAGE_NAME.azure.env', text: 'testKernel.rpm'


### PR DESCRIPTION
All the build names wil have the following format: 
{BUILD_NUMBER}-{KERNEL_PREFIX}-{KERNEL_VERSION}-{KERNEL_TAG}-{BUILD_DATE}
Example: 2-linux-next-4.15.0-611f09f-09022018