### PR TITLE
[lisa] Removed archiving inexistent boot logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,7 +341,6 @@ pipeline {
             }
           post {
             always {
-              archiveArtifacts "${env.BUILD_NAME}${env.BUILD_NUMBER}${env.BRANCH_NAME}\\bootlogs\\*.LOG"
               archiveArtifacts 'lis-test\\WS2012R2\\lisa\\TestResults\\**\\*'
               junit 'lis-test\\WS2012R2\\lisa\\TestResults\\**\\*.xml'
             }

--- a/linux_pipeline/Jenkinsfile_upstream_kernel
+++ b/linux_pipeline/Jenkinsfile_upstream_kernel
@@ -296,7 +296,6 @@ pipeline {
             }
           post {
             always {
-              archiveArtifacts "${env.BUILD_NAME}${env.BUILD_NUMBER}${env.BRANCH_NAME}\\bootlogs\\*.LOG"
               archiveArtifacts 'lis-test\\WS2012R2\\lisa\\TestResults\\**\\*'
               junit 'lis-test\\WS2012R2\\lisa\\TestResults\\**\\*.xml'
             }


### PR DESCRIPTION
As there are no more boot logs created during the hyper-v functional
tests, the whole pipeline will fail when trying to archive those
inexistent boot logs.