### PR TITLE
[package_building] Fix perf package build on debian

### DIFF
--- a/scripts/package_building/build_artifacts.sh
+++ b/scripts/package_building/build_artifacts.sh
@@ -504,7 +504,7 @@ function prepare_perf_debian (){
         exit 3
     else 
         pushd "${source}/tools/perf"
-        change_perf_options "./Makefile.perf" "NO_GTK2=True"
+        change_perf_options "./Makefile.perf" "NO_GTK2=True;NO_LIBAUDIT=True"
         make DESTDIR="$pack_folder" install install-doc
         pushd "$pack_folder"
         mkdir "./usr"


### PR DESCRIPTION
Build debian perf without libaudit support by setting
NO_LIBAUDIT=True in Makefile.perf

If libaudit support is enabled, the perf make will fail on certain
kernels with the error:
`arch/x86/include/generated/asm/syscalls_64.c:370:7: error: expected ]
before x32`