### PR TITLE
[lis-rpm] Changed validation allocation on WS2012

### DIFF
--- a/linux_pipeline/Jenkinsfile_lis_rpm_hyperv
+++ b/linux_pipeline/Jenkinsfile_lis_rpm_hyperv
@@ -36,15 +36,16 @@ def nodesMap = ["sriov":"rhel_7.3,rhel_7.4,centos_7.4,centos_7.3,rhel_7.3_gen2vm
                 "ws2016":"oracle_6.5_rhck,oracle_6.9_rhck,oracle_7.4_rhck,oracle_7.0_rhck,centos_7.0_x64, \
                     centos_7.0_gen2vm,centos_7.2_x64,rhel_7.0,rhel_7.1,rhel_7.2,rhel_6.9_x64,"]
 
-def validationNodesMap = ["ws2016":"rhel_6.9_x64,rhel_7.4,centos_6.8_x64,centos_7.3,centos_7.2_x64,", \
+def validationNodesMap = ["ws2016":"rhel_6.9_x64,rhel_7.4,centos_6.5_x64,centos_7.3,centos_7.2_x64,", \
                           "ws2012r2":"rhel_6.6_x64,centos_7.4_gen2vm,rhel_6.4_32bit,rhel_7.0,centos_6.4_x64,", \
-                          "ws2012":"centos_6.5_x64,rhel_7.1,"]
+                          "ws2012_fvt":"centos_6.8_x64,", \
+                          "ws2012_bvt":"rhel_7.1,"]
                         
-def validationXmlMap = ["lis_pipeline_fvt.xml":"centos_6.5_x64,centos_7.2_x64,rhel_6.6_x64,centos_7.4_gen2vm,rhel_6.9_x64,rhel_7.4,", \
-                        "lis_pipeline_bvt.xml":"centos_6.4_x64,rhel_7.1,rhel_6.4_32bit,rhel_7.0,centos_6.8_x64,centos_7.3,"]
+def validationXmlMap = ["lis_pipeline_fvt.xml":"centos_6.8_x64,centos_7.2_x64,rhel_6.6_x64,centos_7.4_gen2vm,rhel_6.9_x64,rhel_7.4,", \
+                        "lis_pipeline_bvt.xml":"centos_6.4_x64,rhel_7.1,rhel_6.4_32bit,rhel_7.0,centos_6.5_x64,centos_7.3,"]
                     
 def supportedDistros = nodesMap["ws2012"] + nodesMap["ws2012r2"] + nodesMap["ws2016"] + nodesMap["sriov"]
-def supportedValidationDistros = validationNodesMap["ws2012"] + validationNodesMap["ws2012r2"] + validationNodesMap["ws2016"]
+def supportedValidationDistros = validationNodesMap["ws2012_fvt"] + validationNodesMap["ws2012_bvt"] + validationNodesMap["ws2012r2"] + validationNodesMap["ws2016"]
 
 def PowerShellWrapper (psCmd) {
     psCmd = psCmd.replaceAll("\r", "").replaceAll("\n", "")


### PR DESCRIPTION
We will use separe bvt/fvt labels for WS2012 testing to improve the
testing stability.