### PR TITLE
[bisect] made the script more verbose

### DIFF
--- a/linux_pipeline/Jenkinsfile_kernel_bisect_controller
+++ b/linux_pipeline/Jenkinsfile_kernel_bisect_controller
@@ -129,6 +129,7 @@ def validateCommit (String commit, String expectedState) {
                                                             propagate: false,
                                                             wait: true
     if (buildResult.result != expectedState) {
+        println("Commit " + commit + " was expected to be " + expectedState + " instead of " + buildResult.result )
         currentBuild.result = 'FAILURE'
         sh(script: "exit 1")
     }


### PR DESCRIPTION
    added output message to inform that the checked commit
    was not in the expected state