### PR TITLE
[reporting] Added lisa test results parsing to db

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,6 +365,8 @@ pipeline {
                                        string(credentialsId: 'AZURE_SAS', variable: 'AZURE_SAS'),
                                        string(credentialsId: 'AZURE_STORAGE_URL', variable: 'AZURE_STORAGE_URL'),
                                        string(credentialsId: 'LISA_TEST_DEPENDENCIES', variable: 'LISA_TEST_DEPENDENCIES'),
+                                       string(credentialsId: 'DB_CONFIG_KERNEL', variable: 'DB_CONFIG_KERNEL'),
+                                       string(credentialsId: 'LISA_KERNEL_LOG_DESTINATION', variable: 'LISA_KERNEL_LOG_DESTINATION'),
                                        file(credentialsId: 'KERNEL_QUALITY_REPORTING_DB_CONFIG',
                                             variable: 'DBConfigPath')]) {
                 echo 'Running LISA...'
@@ -385,6 +387,8 @@ pipeline {
                         -LisaTestDependencies "${env:LISA_TEST_DEPENDENCIES}"
                         -PipelineName "pipeline-msft-kernel-validation/${env:BRANCH_NAME}"
                         -DBConfigPath "${env:DBConfigPath}"
+                        -LisaLogDBConfigPath "${env:DB_CONFIG_KERNEL}"
+                        -LogsPath "${env:LISA_KERNEL_LOG_DESTINATION}"
                   ''')
                 echo 'Finished running LISA.'
               }

--- a/linux_pipeline/Jenkinsfile_upstream_kernel
+++ b/linux_pipeline/Jenkinsfile_upstream_kernel
@@ -422,6 +422,8 @@ pipeline {
                                        string(credentialsId: 'AZURE_SAS', variable: 'AZURE_SAS'),
                                        string(credentialsId: 'UPSTREAM_AZURE_STORAGE_URL', variable: 'UPSTREAM_AZURE_STORAGE_URL'),
                                        string(credentialsId: 'LISA_TEST_DEPENDENCIES', variable: 'LISA_TEST_DEPENDENCIES'),
+                                       string(credentialsId: 'DB_CONFIG_UPSTREAM', variable: 'DB_CONFIG_UPSTREAM'),
+                                       string(credentialsId: 'LISA_UPSTREAM_LOG_DESTINATION', variable: 'LISA_UPSTREAM_LOG_DESTINATION'),
                                        file(credentialsId: 'KERNEL_QUALITY_REPORTING_DB_CONFIG',
                                             variable: 'DBConfigPath')]) {
                 echo 'Running LISA...'
@@ -444,6 +446,8 @@ pipeline {
                         -LisaTestDependencies "${env:LISA_TEST_DEPENDENCIES}"
                         -PipelineName "pipeline-linux-upstream-validation/${env:BRANCH_NAME}"
                         -DBConfigPath "${env:DBConfigPath}"
+                        -LisaLogDBConfigPath "${env:DB_CONFIG_UPSTREAM}"
+                        -LogsPath "${env:LISA_UPSTREAM_LOG_DESTINATION}"
                   ''')
                 echo 'Finished running LISA.'
               }


### PR DESCRIPTION
lisa test results from msft and upstream pipelines are parsed to the database
using lisa-parser.
Also added the upload of the test results to a specific location.