### PR TITLE
Revert "[package_building] Fix for perf package building"

### DIFF
--- a/scripts/package_building/deps-lis/rpm/perf/lis-perf.spec
+++ b/scripts/package_building/deps-lis/rpm/perf/lis-perf.spec
@@ -33,5 +33,5 @@ mv %{buildroot}%{_usr}/etc %{buildroot}
 %{_bindir}/trace
 %{_usr}/share/*
 %{_usr}/lib64/libperf-jvmti.so
-%{_usr}/*
-
+%{_usr}/lib/examples/perf/bpf/*
+%{_usr}/lib/include/perf/bpf/bpf.h


### PR DESCRIPTION
Reverts LIS/lis-pipeline#255 because main kernel perf tools will fail to install