### PR TITLE
Revert "[package_building] Added new files for perf build in spec file"

### DIFF
--- a/scripts/package_building/deps-lis/rpm/perf/lis-perf.spec
+++ b/scripts/package_building/deps-lis/rpm/perf/lis-perf.spec
@@ -33,5 +33,3 @@ mv %{buildroot}%{_usr}/etc %{buildroot}
 %{_bindir}/trace
 %{_usr}/share/*
 %{_usr}/lib64/libperf-jvmti.so
-%{_usr}/lib/examples/perf/bpf/*
-%{_usr}/lib/include/perf/bpf/bpf.h


### PR DESCRIPTION
Reverts LIS/lis-pipeline#254 because main kernel perf tools will fail to install