### PR TITLE
lcow: Fix opengcs makefile path

### DIFF
--- a/scripts/linux_containers_on_windows/build_opengcs_tools.sh
+++ b/scripts/linux_containers_on_windows/build_opengcs_tools.sh
@@ -23,7 +23,7 @@ function build_opengcs() {
     fi
 
     echo "$PATH"
-    make -j"${thread_num}"
+    make -j"${thread_num}" "bin/gcstools"
     popd
 
     echo "Opengcs tools artifacs built successfully"
@@ -74,8 +74,8 @@ function copy_artifacts() {
     artifacts_folder="$1"; shift
     destination_path="$1"
     
-    atifact_exists="$(ls $artifacts_folder/* || true)"
-    if [[ "$atifact_exists" != "" ]];then
+    artifact_exists="$(ls $artifacts_folder/* || true)"
+    if [[ "$artifact_exists" != "" ]];then
         cp "$artifacts_folder"/* "$destination_path"
     fi
 }
@@ -117,7 +117,7 @@ function main {
     done
 
     OPENGCS_BASE_BUILD_DIR="${BUILD_BASE_DIR}/opengcs-build-folder"
-    OPENGCS_BUILD_DIR="${GOPATH}/src/github.com/Microsoft/opengcs/service"
+    OPENGCS_BUILD_DIR="${GOPATH}/src/github.com/Microsoft/opengcs"
     OPENGCS_ARTIFACT_DIR="${OPENGCS_BUILD_DIR}/bin"
 
     echo "GOPATH is: $GOPATH"


### PR DESCRIPTION
The Makefile path changed from service/Makefile to Makefile in the
following commit:
https://github.com/Microsoft/opengcs/commit/b837a2b56f0b932e302b653aff78efdc2d13df62#diff-b67911656ef5d18c4ae36cb6741b7965