### PR TITLE
[package_building] Replace `make rpm` with `make rpm-pkg`

### DIFF
--- a/scripts/package_building/build_artifacts.sh
+++ b/scripts/package_building/build_artifacts.sh
@@ -659,7 +659,7 @@ function build_rhel {
             rm -f $source_package_dir/*
         fi
         pushd "$source"
-        make rpm -j"$thread_number"
+        make rpm-pkg -j"$thread_number"
         sed -i -e "s/echo \"Name:.*/echo \"Name: kernel\"/g" "./scripts/package/mkspec"
         popd
         copy_artifacts "$source_package_dir" "$destination_path"

--- a/scripts/package_building_bisect/build_artifacts_bisect.sh
+++ b/scripts/package_building_bisect/build_artifacts_bisect.sh
@@ -302,7 +302,7 @@ function build_rhel {
     fi
 
     pushd "$repository"
-    make rpm -j"$thread_number"
+    make rpm-pkg -j"$thread_number"
     sed -i -e "s/echo \"Name:.*/echo \"Name: kernel\"/g" "./scripts/package/mkspec"
     popd
     copy_artifacts "$artifacts_dir" "$destination_path"


### PR DESCRIPTION
"make rpm" is obsolete now, has been replaced with "make rpm-pkg".

Reference: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=dd5806ede3d71b7577d1d9ec853755709b6b40fa