### PR TITLE
lcow: Fixed linuxkit stage for RS5

### DIFF
--- a/linux_pipeline/Jenkinsfile_container_images
+++ b/linux_pipeline/Jenkinsfile_container_images
@@ -34,7 +34,7 @@ properties ([
             description: 'Build kernel in docker container', 
             name: 'kernel_builder'],
         [$class: 'ChoiceParameterDefinition',
-            choices: "RS4\nRS5",
+            choices: "RS5\nRS4",
             name: 'HOST_VERSION',
             description: 'Windows host versions.']
         ]

--- a/linux_pipeline/Jenkinsfile_container_images
+++ b/linux_pipeline/Jenkinsfile_container_images
@@ -58,10 +58,6 @@ testMap = ["test_functional":"linuxkit","test_stress":"docker_stress,opengcs_bui
 def hostName = versionsMap[env.HOST_VERSION]
 skipBuild = false
 
-if (env.HOST_VERSION == "RS5") {
-    env["linuxkit"] = "false"
-}
-
 def runTests(versionsMap, hostName){
     testMap.keySet().each {
         def section = it

--- a/scripts/lcow/Build-OpenGCS.ps1
+++ b/scripts/lcow/Build-OpenGCS.ps1
@@ -7,8 +7,6 @@ param (
     [String] $LogDestination
 )
 
-$ErrorActionPreference = "Stop"
-
 $scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $commonModulePath = Join-Path $scriptPath "CommonFunctions.psm1"
 Import-Module $commonModulePath

--- a/scripts/lcow/Prepare-Env.ps1
+++ b/scripts/lcow/Prepare-Env.ps1
@@ -8,7 +8,7 @@ $TEST_DEPENDENCIES = @{
     "dockerd.exe" = "https://master.dockerproject.org/windows/x86_64/dockerd.exe";
     "docker.exe" = "https://master.dockerproject.org/windows/x86_64/docker.exe";
     "docker-compose.exe" = "https://github.com/docker/compose/releases/download/1.21.0-rc1/docker-compose-Windows-x86_64.exe";
-    "rtf.exe" = "https://69-89472225-gh.circle-artifacts.com/0/rtf-windows-amd64.exe"
+    "rtf.exe" = "https://kernelstorageacc.blob.core.windows.net/lcow-bin/rtf.exe"
 }
 
 $ErrorActionPreference = "Stop"

--- a/scripts/lcow/Run-LinuxKit.ps1
+++ b/scripts/lcow/Run-LinuxKit.ps1
@@ -7,8 +7,6 @@ param (
     [String] $LogDestination
 )
 
-$ErrorActionPreference = "Stop"
-
 $scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $commonModulePath = Join-Path $scriptPath "CommonFunctions.psm1"
 Import-Module $commonModulePath

--- a/scripts/lcow/Run-StressTest.ps1
+++ b/scripts/lcow/Run-StressTest.ps1
@@ -8,7 +8,6 @@ param (
 )
 
 $TEST_CONTAINER_NAME = "stress-test"
-$ErrorActionPreference = "Stop"
 
 $scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $commonModulePath = Join-Path $scriptPath "CommonFunctions.psm1"


### PR DESCRIPTION
Using a custom compiled rtf for Windows binary that works on hosts with multiple physical CPUs.
Removing Stop preference due to script failure when doing error output.