### PR TITLE
watcher-ubuntu-azure: Added container deploy

### DIFF
--- a/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_validation
+++ b/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_validation
@@ -35,7 +35,7 @@ def AZURE_VALIDATION_TESTS_HASH = [BVT:"-TestCategory 'BVT'",
     FUNCTIONAL_COMMON:"-TestCategory 'Functional' -TestArea 'CORE,KVP,KDUMP,STORAGE'",
     FUNCTIONAL_SRIOV:"-TestCategory 'Functional' -TestArea 'SRIOV'"]
 def AZURE_PERFORMANCE_TESTS_HASH = [PERFORMANCE_NETWORK:"-TestCategory 'Performance' -TestArea 'Network'",
-    PERFORMANCE_STORAGE:"-TestCategory 'Performance' -TestArea 'Storage'"]
+    PERFORMANCE_STORAGE:"-TestNames 'PERF-STORAGE-4K-IO,PERF-STORAGE-1024K-IO,PERF-STORAGE-OVER-NFS-Synthetic-TCP-4K,PERF-STORAGE-OVER-NFS-Synthetic-UDP-4K,PERF-STORAGE-OVER-NFS-SRIOV-TCP-4K,PERF-STORAGE-OVER-NFS-SRIOV-UDP-4K' -StorageAccount 'ExistingStorage_Premium'"]
 LATEST_VERSION_LOCATION="/home/lisa/latest_versions.sh"
 PLATFORM_HYPERV = "hyperv"
 PLATFORM_AZURE = "azure"

--- a/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_watcher
+++ b/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_watcher
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 properties ([
-    pipelineTriggers([cron('H */6 * * *')])
+    pipelineTriggers([cron('H */4 * * *')])
 ])
 
 env.VERSION_TO_TEST = "/home/lisa/version_to_test.sh"
@@ -38,7 +38,7 @@ node ("meta_slave") {
                 if (will_test == "yes") {
                     SEND_MAIL = "yes"
                     println "TRIGGERING the testing for ${distro} distro, ${kernel} kernel - ${latest_kernel_version}"
-                    MESSAGE_LIST = MESSAGE_LIST + "${distro} ${latest_kernel_version} ${kernel} kernel, "
+                    MESSAGE_LIST = MESSAGE_LIST + "<br>${distro} ${latest_kernel_version} ${kernel} kernel, "
                     build (job: "${env.PIPELINE_NAME}/master",
                         parameters: [
                             string(name: 'Distro', value: "${distro}"),
@@ -48,8 +48,6 @@ node ("meta_slave") {
                             string(name: 'sendMail', value: "yes"),
                         ],
                         wait: false, propagate: false)
-                } else {
-                    println "Not triggering testing for ${distro} distro, ${kernel} kernel"
                 }
             }
             deleteDir()

--- a/scripts/ubuntu_azure_kernel/ubuntu_azure_kernel_watcher.sh
+++ b/scripts/ubuntu_azure_kernel/ubuntu_azure_kernel_watcher.sh
@@ -2,6 +2,97 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 
+# DESCRIPTION
+#
+#    This bash script is looking for linux-azure and linux-azure-edge proposed
+# kernels. There are 4 Ubuntu versions checked: Trusty, Xenial, Bionic, Cosmic.
+# It will take the latest version available for each using apt-cache and compare
+# it to latest known version.
+#
+# -- If there is a new version, an Azure container will be deployed matching the
+# distro version and a proposed kernel install will be attempted: -
+# ----- If the install is successful, this script will save on a file the info 
+# that a new kernel has to be validated. The Jenkinsfile 
+# (Jenkinsfile_ubuntu_azure_kernel_watcher) will get that data and will trigger
+# the validation job for the new available kernel
+# ----- If the install in the container is not successful, the Jenkinsfile will
+# not trigger the validation job. It will wait until the next watcher trigger,
+# usually 4 hours.
+#
+# -- If there isn't a new kernel version available, the Jenkinsfile will
+# not trigger the validation job. It will wait until the next watcher trigger,
+# usually 4 hours.
+
+function Search_New_Kernel() {
+    release=$1
+    kernel_type=$2
+    old_kernel_version=$3
+    if [ ${kernel_type} == "linux-azure" ]; then
+        kernel_type_short="_azure"
+    else
+        kernel_type_short="_edge"
+    fi
+
+    latest_kernel=$(sudo apt-cache madison ${kernel_type} | grep ${release}-proposed | awk '{print $3}')
+    if [ ! -z $latest_kernel ]; then
+        echo "Latest $kernel_type Kernel for $release is $latest_kernel"
+        echo "Old $kernel_type kernel for $release : $old_kernel_version"
+        if [ $old_kernel_version != $latest_kernel ]; then
+            echo "Deploying $kernel_type kernel on a $release image container to validate the install"
+            Deploy_Container $release $kernel_type
+            if [ $? -ne 0 ]; then
+                echo "SKIPPING validation for $kernel_type on ${release}. Kernel couldn't be installed!"
+                echo "Will try again the install in 4 hours"
+            else
+                echo "Setting $release $kernel_type for validation testing" 
+                # Updating the value in latest_versions.sh
+                sudo sed -i -e "s|${release}${kernel_type_short}=.*|${release}${kernel_type_short}=${latest_kernel}|g" $VERSION_HISTORY_LOCATION
+                sudo sed -i -e "s|${release},${kernel_type},.*|${release},${kernel_type},yes;|g" $VERSION_TO_TEST_LOCATION  
+            fi
+        else
+            echo "NO NEW VERSIONS are available for $release proposed $kernel_type kernel"
+            sudo sed -i -e "s|${release},${kernel_type},.*|${release},${kernel_type},no;|g" $VERSION_TO_TEST_LOCATION
+        fi
+    else
+        echo "Proposed $kernel_type kernel NOT AVAILABLE for $release"
+        sudo sed -i -e "s|${release},${kernel_type},.*|${release},${kernel_type},no;|g" $VERSION_TO_TEST_LOCATION
+    fi
+}
+
+function Deploy_Container() {
+    release=$1
+    kernel=$2
+    retval=1
+    rg_name="ubuntu-${release}-${kernel}"
+    container_name="kerneltest"
+
+    az group create --name $rg_name --location "westus2" > /dev/null 2>&1
+read -r -d '' cmd_to_send <<- EOM
+echo "deb http://archive.ubuntu.com/ubuntu/ ${release}-proposed restricted main multiverse universe" >> /etc/apt/sources.list
+export DEBIAN_FRONTEND=noninteractive
+apt-get clean all
+apt-get -y update
+echo "apt-get install -y ${kernel}/${release}"
+apt-get install -y ${kernel}/${release}
+EOM
+    az container create -g $rg_name --name $container_name --image "ubuntu:${release}" --command-line "bash -c '$cmd_to_send'" > /dev/null 2>&1
+    sleep 30
+
+    # Get logs
+    container_logs=$(az container logs --resource-group $rg_name --name $container_name)
+    kernel_count=$(echo $container_logs | grep "The following NEW packages will be installed:" -c)
+    if [ $kernel_count -eq 1 ]; then
+        retval=0
+    else
+        echo $container_logs
+        echo ""
+    fi
+    az group delete --name $rg_name --yes
+
+    return $retval
+}
+
+# Main
 RELEASES=(trusty xenial bionic cosmic)
 VERSION_HISTORY_LOCATION="/home/lisa/latest_versions.sh"
 VERSION_TO_TEST_LOCATION="/home/lisa/version_to_test.sh"
@@ -19,37 +110,10 @@ for release in ${RELEASES[@]}; do
 
     latest_azure=$(sudo apt-cache madison linux-azure | grep ${release}-proposed | awk '{print $3}')
     latest_edge=$(sudo apt-cache madison linux-azure-edge | grep ${release}-proposed | awk '{print $3}')
-    if [ ! -z $latest_azure ]; then
-        echo "Latest Azure Kernel for $release is $latest_azure"
-        echo "Old Azure kernel for $release : $azure_release"
-        if [ $azure_release != $latest_azure ]; then
-            echo "We have a new kernel. Triggering $release azure kernel testing"
-            # Updating the value in latest_versions.sh
-            sudo sed -i -e "s|${release}_azure=.*|${release}_azure=${latest_azure}|g" $VERSION_HISTORY_LOCATION
-            sudo sed -i -e "s|${release},linux-azure,.*|${release},linux-azure,yes;|g" $VERSION_TO_TEST_LOCATION
-        else
-            echo "No new proposed azure kernel found for $release"
-            sudo sed -i -e "s|${release},linux-azure,.*|${release},linux-azure,no;|g" $VERSION_TO_TEST_LOCATION
-        fi
-    else
-        echo "Proposed Azure kernel not available for $release"
-        sudo sed -i -e "s|${release},linux-azure,.*|${release},linux-azure,no;|g" $VERSION_TO_TEST_LOCATION
-    fi
+    
+    # Check linux-azure proposed kernel for a new version
+    Search_New_Kernel $release "linux-azure" $azure_release
 
-    if [ ! -z $latest_edge ]; then
-        echo "Latest Edge Kernel for $release is $latest_edge"
-        echo "Old Edge kernel for $release : $edge_release"
-        if [ $edge_release != $latest_edge ]; then
-            echo "We have a new kernel. Triggering $release edge kernel testing"
-            # Updating the value in latest_versions.sh
-            sudo sed -i -e "s|${release}_edge=.*|${release}_edge=${latest_edge}|g" $VERSION_HISTORY_LOCATION
-            sudo sed -i -e "s|${release},linux-azure-edge,.*|${release},linux-azure-edge,yes;|g" $VERSION_TO_TEST_LOCATION
-        else
-            echo "No new proposed edge kernel found for $release"
-            sudo sed -i -e "s|${release},linux-azure-edge,.*|${release},linux-azure-edge,no;|g" $VERSION_TO_TEST_LOCATION
-        fi
-    else
-        echo "Proposed Azure edge kernel not available for $release"
-        sudo sed -i -e "s|${release},linux-azure-edge,.*|${release},linux-azure-edge,no;|g" $VERSION_TO_TEST_LOCATION
-    fi
+    # Check linux-azure-edge proposed kernel for a new version
+    Search_New_Kernel $release "linux-azure-edge" $edge_release
 done


### PR DESCRIPTION
An additional check was added to the watcher: If a kernel is detected, an Azure container will be deployed to check if the kernel can actually be installed.
- If it can be installed, then the validation job will be triggered. 
- If not, the kernel version will remain the old one and the next watcher run (after 4 hours) will retry to install the new kernel again.

Small fixes added too:
- Refactored the watcher: Added more comments and outputs; Remove duplicate code
- Added Premium storage for Azure Storage Perf
- Removed 2 Azure Storage Perf TCs
- Reduced watcher roles (kernel check and retry install) cron to 4 hours.

**LE: Can confirm that the change is having the expected behavior.
A set of azure kernels have been detected, first install failed, at the next run the install was successful and validation was triggered.**
