### PR TITLE
azure: bisect: fix lisav2 params

### DIFF
--- a/linux_pipeline/Jenkinsfile_azure_latest_image
+++ b/linux_pipeline/Jenkinsfile_azure_latest_image
@@ -68,7 +68,7 @@ azureImages.each {
                                 " -StorageAccount 'ExistingStorage_Standard'" +
                                 " -XMLSecretFile '${Azure_Secrets_File}'" +
                                 " -UseManagedDisks" +
-                                " -ForceDeleteResources" +
+                                " -ResourceCleanup 'Delete'" +
                                 " -ExitWithZero"
                                 )
                                 junit "Report\\*-junit.xml"

--- a/linux_pipeline/Jenkinsfile_kernel_bisect_commit_validator
+++ b/linux_pipeline/Jenkinsfile_kernel_bisect_commit_validator
@@ -337,7 +337,7 @@ def runLisa(platform, secrets, testName, testCategory, testArea, testTag, custom
         " -TestTag '${testTag}'" +
         " -CustomParameters '${customTestParams}'" +
         " -StorageAccount 'ExistingStorage_Standard'" +
-        " -ForceDeleteResources" +
+        " -ResourceCleanup 'Delete'" +
         " -XMLSecretFile '${secrets}'"
 
     )


### PR DESCRIPTION
Because of PR https://github.com/LIS/LISAv2/pull/697,
the parameter -ForceDeleteResources has been replaced by
-ResourceCleanup 'Delete'