### PR TITLE
Fix local path flag and git output in source variable for local build

### DIFF
--- a/scripts/package_building/build_artifacts.sh
+++ b/scripts/package_building/build_artifacts.sh
@@ -187,13 +187,13 @@ function get_sources_local (){
     pushd "${base_dir}/kernel"
     cp -rf "$source_path" .
     source="${base_dir}/kernel/$(ls)"
-    echo "$source"
     popd
     pushd "$source"
     if [[ -d ".git" ]];then
-        git checkout $git_branch||true
+        git checkout $git_branch > /dev/null||true
     fi
     popd
+    echo "$source"
 }
 
 function prepare_kernel_debian (){
@@ -925,7 +925,7 @@ function main {
             --local_path)
                 case "$2" in
                     "") shift 2 ;;
-                    *) SOURCE_PATH="$2" ; DOWNLOAD_METHOD='local' shift 2 ;;
+                    *) SOURCE_PATH="$2" ; DOWNLOAD_METHOD='local' ; shift 2 ;;
                 esac;;
             --build_path)
                 case "$2" in


### PR DESCRIPTION
* `$DOWNLOAD_METHOD` remains empty
* `$source`  has git output in it `Already on branch [...]` etc.
