### PR TITLE
rhel kernel pipeline: Add support for RHEL 7.6

### DIFF
--- a/linux_pipeline/Jenkinsfile_rhel_kernel_validation
+++ b/linux_pipeline/Jenkinsfile_rhel_kernel_validation
@@ -22,7 +22,7 @@ withCredentials(bindings: [string(credentialsId: 'LIS_ARCHIVE_LINK',
 
 def sendMail = true
 def stashList = []
-def azureSku = ["rhel_6.7": "6.7", "rhel_6.8": "6.8", "rhel_6.9": "6.9", "rhel_6.10": "6.10", "rhel_7.3": "7.3", "rhel_7.4": "7.4", "rhel_7.5": "7-RAW"]
+def azureSku = ["rhel_6.7": "6.7", "rhel_6.8": "6.8", "rhel_6.9": "6.9", "rhel_6.10": "6.10", "rhel_7.3": "7.3", "rhel_7.4": "7.4", "rhel_7.5": "7-RAW", "rhel_7.6": "7.6"]
 
 def getVersionFromURL(lisLink){
     def realLink = ""

--- a/scripts/azure_kernel_validation/azure_templates/rhel_deploy/azuredeploy.json
+++ b/scripts/azure_kernel_validation/azure_templates/rhel_deploy/azuredeploy.json
@@ -18,10 +18,10 @@
       "type": "string",
       "defaultValue": "7.4",
       "allowedValues": [
-        "7-RAW","7.5", "7.4", "7.3", "6.10", "6.9", "6.8", "6.7"
+        "7.6", "7-RAW", "7.5", "7.4", "7.3", "6.10", "6.9", "6.8", "6.7"
       ],
       "metadata": {
-        "description": "The RHEL version for the VM. This will pick a fully patched image of this given RHEL version. Allowed values: 7.3, 7.4, 7.5"
+        "description": "The RHEL version for the VM. This will pick a fully patched image of this given RHEL version. Allowed values: 7.3, 7.4, 7.5, 7.6"
       }
     },
     "sshKeyData": {

--- a/scripts/rhel_validation/get_kernel_version.ps1
+++ b/scripts/rhel_validation/get_kernel_version.ps1
@@ -47,7 +47,8 @@ $RHEL_VERSIONS_TO_KERNEL_MAP = @{"rhel_6.7" = @{"baseVer" = "2.6.32-573"; "newVe
                                  "rhel_6.10" = @{"baseVer" = "2.6.32-754"; "newVer" = @()};
                                  "rhel_7.3" = @{"baseVer" = "3.10.0-514"; "newVer" = @()};
                                  "rhel_7.4" = @{"baseVer" = "3.10.0-693"; "newVer" = @()};
-                                 "rhel_7.5" = @{"baseVer" = "3.10.0-862"; "newVer" = @()}}
+                                 "rhel_7.5" = @{"baseVer" = "3.10.0-862"; "newVer" = @()};
+                                 "rhel_7.6" = @{"baseVer" = "3.10.0-957"; "newVer" = @()}}
 
 function Get-StoredVersions {
     param (

--- a/scripts/rhel_validation/prepare_lis_vm.sh
+++ b/scripts/rhel_validation/prepare_lis_vm.sh
@@ -99,7 +99,7 @@ function main {
         fi
         prepare_vm "$OS_VERSION" "$KERNEL_REPO" "$KERNEL_VERSION" "$RHEL_USERNAME" "$RHEL_PASSWORD"
     elif [[ "$SECTION" == "install_lis" ]];then
-        MODULES_DIR="$(get_lis_os RHEL "${OS_VERSION}")"
+        MODULES_DIR="$(get_lis_os RPMS "${OS_VERSION}")"
         install_modules "${LIS_PATH}/${MODULES_DIR}" "$KERNEL_VERSION"
     fi
     popd

--- a/scripts/rhel_validation/validate_rhel_vm.sh
+++ b/scripts/rhel_validation/validate_rhel_vm.sh
@@ -19,7 +19,7 @@ run_remote_az_commands() {
     COMMANDS="$4"
     PARAMS="$5"
     
-    TIMEOUT=600
+    TIMEOUT=1800
     
     IFS=';'; COMMANDS=($COMMANDS); unset IFS;
     for comm in "${COMMANDS[@]}"; do


### PR DESCRIPTION
This PR is to extend pipeline-redhat-kernel-lis-validation to detect 7.6 latest errata kernels