### PR TITLE
Support errata kernel download from different Repo

### DIFF
--- a/linux_pipeline/Jenkinsfile_rhel_kernel_validation
+++ b/linux_pipeline/Jenkinsfile_rhel_kernel_validation
@@ -105,6 +105,7 @@ stage ("Test kernel") {
                             def repolist = line.trim().split("=")[1]
                             if (kernel.matches(version)) {
                                 kernelrepolist=repolist
+                                break
                             }
                         }
                         def exitCode = sh (returnStatus: true, script: """

--- a/linux_pipeline/Jenkinsfile_rhel_kernel_validation
+++ b/linux_pipeline/Jenkinsfile_rhel_kernel_validation
@@ -54,8 +54,10 @@ stage ("Check for kernel") {
                         -LatestVersionsFile "${env:UTILS_DIR}\\latest_tested_versions.txt"
                         -RemoteHtmlLocation "${env:REMOTE_HTML_LOCATION}"
                         -OutputFile "kernel_versions.txt"
+                        -RepoListOutFile "Kernel_Repolist.txt"
                 ''') // LatestVersionsFile changed
                 stash includes: 'kernel_versions.txt', name: 'kernel_versions'
+                stash includes: 'Kernel_Repolist.txt', name: 'Kernel_Repolist'
                 echo 'Kernel versions checked'
                 deleteDir()
             }
@@ -67,8 +69,10 @@ stage ("Test kernel") {
     node ("jenkins-meta-slave") {
         def runNumber = 1
         def runs = [:]
+        def kernelrepolist = ""
         dir ("rhel_versions-" + env.BUILD_NUMBER + env.BRANCH_NAME) {
             unstash 'kernel_versions'
+            unstash 'Kernel_Repolist'
         }
         versionsPath = "./rhel_versions-${env.BUILD_NUMBER}${env.BRANCH_NAME}/kernel_versions.txt"
         kernelVersions = readFile(versionsPath)
@@ -78,6 +82,9 @@ stage ("Test kernel") {
             currentBuild.result = 'SUCCESS'
             return
         }
+        kernelrepolistPath = "./rhel_versions-${env.BUILD_NUMBER}${env.BRANCH_NAME}/Kernel_Repolist.txt"
+        kernelrepolists = readFile(kernelrepolistPath)
+        kernelrepolists = kernelrepolists.trim().replaceAll("[^A-Za-z0-9.=_;\\-\\^\\s]", "").split(";")
         kernelVersions = kernelVersions.replaceAll("[^A-Za-z0-9.=_;\\-]", "").split(";")
         kernelVersions.each() {
             def distro = it.split("=")[0]
@@ -93,6 +100,13 @@ stage ("Test kernel") {
                         runNumber = runNumber + 1
                         checkout scm
                         echo "Testing kernel: ${version} on distro: ${distro}"
+                        for (line in kernelrepolists) {
+                            def kernel = line.trim().split("=")[0]
+                            def repolist = line.trim().split("=")[1]
+                            if (kernel.matches(version)) {
+                                kernelrepolist=repolist
+                            }
+                        }
                         def exitCode = sh (returnStatus: true, script: """
                             bash scripts/rhel_validation/validate_rhel_vm.sh \
                                 --workdir "r-${distro}-${version}-${env.BUILD_NUMBER}-${env.BRANCH_NAME}" \
@@ -103,6 +117,7 @@ stage ("Test kernel") {
                                 --rhel_username '${USERNAME}' \
                                 --rhel_password '${PASSWORD}' \
                                 --sku "${azureSku[distro]}" \
+                                --kernelrepolist "${kernelrepolist}" \
                                 --azure_token '${AZURE_SAS}'
                         """)
                         archiveArtifacts artifacts: "${distro}_lis_install.log"

--- a/scripts/rhel_validation/get_kernel_version.ps1
+++ b/scripts/rhel_validation/get_kernel_version.ps1
@@ -168,7 +168,7 @@ Function Get-KernelRepositoryName {
                 break;
             }
             if ($line -imatch '<br') {
-                $RepoList += $line.Trim().Split(" ")[0] + "^"
+                $RepoList += $line.Trim().Split("<")[0].Trim() + "^"
             }
         }
     }

--- a/scripts/rhel_validation/get_kernel_version.ps1
+++ b/scripts/rhel_validation/get_kernel_version.ps1
@@ -37,7 +37,8 @@ param (
     [String] $LatestVersionsFile,
     [String] $OutputFile,
     [String] $RemoteHtmlLocation,
-    [String] $UtilsDir
+    [String] $UtilsDir,
+    [String] $RepoListOutFile
 )
 
 # generate hash table with list of kernels for each version of rhel
@@ -141,6 +142,39 @@ function Get-UpdatedVersionsList {
     return $resultList, $latestVersionsList
 }
 
+Function Get-KernelRepositoryName {
+    param (
+        [string] $Kernel_link,
+        [string] $kernelhtmlRepo,
+        [string] $CookiePath
+    )
+
+    $RepoList=''
+    $isTextDetected = $false
+    $isTableDetected = $false
+    $PrefixURL = "https://access.redhat.com"
+    $fullURL = $PrefixURL + $Kernel_link
+    Get-VersionsHtml -HtmlPath $kernelhtmlRepo -RemoteUrl $fullURL -CookiePath  $CookiePath
+    $RepoData = Get-Content -Path $kernelhtmlRepo -Raw
+    foreach ($line in $RepoData.split("`n")) {
+        if ($line -imatch "Repos shown are based on your active subscriptions") {
+            $isTextDetected = $true
+        }
+        if ($line -imatch "<table") {
+            $isTableDetected = $true
+        }
+        if ($isTextDetected -and $isTableDetected ) {
+            if ($line -imatch '</table>') {
+                break;
+            }
+            if ($line -imatch '<br') {
+                $RepoList += $line.Trim().Split(" ")[0] + "^"
+            }
+        }
+    }
+    return $RepoList
+}
+
 ################################################################################
 #
 # Main script body
@@ -157,6 +191,9 @@ function Main {
     New-Item -Path $OutputFile -Force
     $OutputFile = Resolve-Path $OutputFile
     
+    New-Item -Path $RepoListOutFile -Force
+    $RepoListOutFile = Resolve-Path $RepoListOutFile
+
     $latestVersionsHash = Get-StoredVersions -LatestVersionsFile $LatestVersionsFile
     
     Push-Location $WorkDir
@@ -168,6 +205,19 @@ function Main {
 
     if ($resultList) {
         Write-Output "${resultList}" | Out-File $OutputFile
+        $kernelVersions = ($resultlist -replace "rhel_\d+.\d+=","").Split(";").trim()
+        foreach ($kernel in $kernelVersions) {
+            if ($kernel) {
+                $kernelhtmlpath=Get-Content -Path ".\package.html" | `
+                          where { $_ | Select-String -Pattern $kernel } | `
+                          where { $_ | Select-String -Pattern 'x86_64' } | `
+                          where { $_ | Select-String -Pattern 'value="(.*)"' }
+                $kernelpath=$kernelhtmlpath.ToString().Trim() -replace 'value=',"" -replace '\"',''
+                $RepoList=Get-KernelRepositoryName -CookiePath $cookiePath -Kernel_link $kernelpath -kernelhtmlRepo "repo.html"
+                $ResultRepoList += @("{0}={1};" -f @($kernel, $RepoList))
+            }
+        }
+        Write-Output "${ResultRepoList}" | Out-File $RepoListOutFile
     } else {
         Write-Output "No new kernel versions were found"
     }

--- a/scripts/rhel_validation/validate_rhel_vm.sh
+++ b/scripts/rhel_validation/validate_rhel_vm.sh
@@ -99,6 +99,9 @@ main() {
             --sku)
                 AZURE_SKU="$2"
                 shift 2;;
+            --kernelrepolist)
+                KERNEL_REPO_LIST="$2"
+                shift 2;;
             --azure_token)
                 AZURE_TOKEN="$2"
                 shift 2;;
@@ -133,7 +136,7 @@ main() {
     # Install the desired kernel version
     run_remote_az_commands "$RESOURCE_GROUP" "$FULL_VM_NAME" "full_output" \
         "@prepare_lis_vm.sh" \
-        "sec=install_kernel os_ver=\"$OS_VERSION\" workdir=\"/root/\" \
+        "sec=install_kernel kernel_repolist=\"$KERNEL_REPO_LIST\" os_ver=\"$OS_VERSION\" workdir=\"/root/\" \
             kernel_ver=\"$KERNEL_VERSION\" rhel_user=\"$USERNAME\" rhel_pass=\"$PASSWORD\""
     
     # Reboot vm


### PR DESCRIPTION
Current pipeline-redhat-kernel-lis-validation enables only EUS Repo to install the kernel.
So, Enhanced this to detect dynamically list of repos where the kernel is available through kernel package downloadable link and will enable these repos through subscription manger before installing the kernel