### PR TITLE
Azure daily images: disable branch indexing

### DIFF
--- a/linux_pipeline/Jenkinsfile_azure_latest_image
+++ b/linux_pipeline/Jenkinsfile_azure_latest_image
@@ -5,6 +5,7 @@ def RunPowershellCommand(psCmd) {
 }
 
 properties ([
+    overrideIndexTriggers(false),
     [$class: 'ParametersDefinitionProperty',
         parameterDefinitions: [
         [$class: 'StringParameterDefinition',


### PR DESCRIPTION
Build is triggered by watcher, should not be triggered by branch indexing.