### PR TITLE
ubuntu_kernel: fix db report with non signed kernel

### DIFF
--- a/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_validation
+++ b/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_validation
@@ -485,7 +485,7 @@ if (env.sendMail == "yes"){
                         """
                     )
                 } catch (exc) {
-                    owner = exc.getCauses()[0].getUser()
+                    owner = exc.getCauses()[0].getUser().toString()
                     env.SIGNED_OFF_BY = owner
                     env.SIGNED_OFF_RESULT = "false"
                     emailext (


### PR DESCRIPTION
Because owner = exc.getCauses()[0].getUser() is not serializable, the env variable cannot be set and it fails with java.io.NotSerializableException: hudson.model.User

Adding toString to the user fixes the error.