### PR TITLE
Ubuntu Azure Kernels: Fix empty mail list for sign-off stage

### DIFF
--- a/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_validation
+++ b/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_validation
@@ -484,7 +484,7 @@ node ("meta_slave") {
         withCredentials([string(credentialsId: 'MAIL_LIST_SIGNOFF', variable: 'MAIL_LIST_SIGNOFF')]) {
             def emailList = ""
             if (env.sendMail == "yes") {
-                emailList = env.MAIL_LIST_OWNER
+                emailList = env.MAIL_LIST_SIGNOFF
             }
             try {
                 checkout scm


### PR DESCRIPTION
`emailList` remained empty because the wrong variable was used.