### PR TITLE
Shorten RGIdentifier.

### DIFF
--- a/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_validation
+++ b/linux_pipeline/Jenkinsfile_ubuntu_azure_kernel_validation
@@ -354,7 +354,7 @@ if (env.ValidationHyperV == 'yes') {
                                         echo "Run-LisaV2.ps1 -TestPlatform 'HyperV' -OsVHD ${HYPERV_VHD_PATH} -RgIdentifier 'ubuntuAzure${distro}' -TestLocation '${test_location}' -CustomKernel '${KERNEL_TYPE}' ${test_cmd} -XMLSecretFile '${HYPERV_LISAV2_SECRETS}'"
                                         RunPowershellCommand(".\\Run-LisaV2.ps1" +
                                             " -TestLocation '${test_location}'" +
-                                            " -RGIdentifier 'ubuntuAzure${distro}'" +
+                                            " -RGIdentifier 'ubuntuHV${distro}'" +
                                             " -TestPlatform 'HyperV'" +
                                             " -CustomKernel '${KERNEL_TYPE}'" +
                                             " -OsVHD '${HYPERV_VHD_PATH}'" +

--- a/scripts/package_building/utils.sh
+++ b/scripts/package_building/utils.sh
@@ -253,7 +253,7 @@ get_stable_branches() {
     git_dir="$1"
 
     pushd "$git_dir"
-    branches=$(git branch -r | sort | grep "origin/linux-msft.*y" | grep -v "staging" | grep -v "proposed")
+    branches=$(git branch -r | sort | grep "origin/linux-msft.*y" | grep -v "staging" | grep -v "proposed" | grep -v "wsl")
     for branch in $branches;do
         small_branch="${branch/origin\//}"
         tag=$(get_git_tag "." $branch)


### PR DESCRIPTION
Before fix, the hostname is too long, getconf HOST_NAME_MAX return 64.
But 'LISAv2-TwoVM1Dep-ubuntuAzuredisco-OU41-637002911910-dependency-vm' is 65.
When inject hostname, VM only accept 64 characters, but in /etc/hosts file, we use above string, this cause test case failed.
···
[LISAv2 Test Results Summary]
Test Run On           : 08/02/2019 05:40:48
VHD Under Test        : ubuntu_19.04_gen1_gen2.vhdx
Initial Kernel Version: 5.0.0-15-generic
Final Kernel Version  : 5.0.0-1013-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:11

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              NET-JUMBO-FRAMES                                                                  PASS                 4.94 
···