### PR TITLE
check_latest_tags : check updated to current supported versions

### DIFF
--- a/linux_pipeline/Jenkinsfile_dpdk_pipeline
+++ b/linux_pipeline/Jenkinsfile_dpdk_pipeline
@@ -124,6 +124,7 @@ def azureRegion = env.AZURE_REGION.trim()
 def testCases = env.TEST_CASE.trim()
 def testCaseTag = env.TEST_TAG.trim()
 def dpdkSource = []
+def dpdkVersionPattern = ~/^v((1[8-9])\.(\d{1,3}))|(([2-9][0-9])\.\d{1,3})$/
 
 if (!azureImages || !azureRegion || !testCases || !testCaseTag) {
   throw 'Failed to validate the pipeline parameters'
@@ -166,7 +167,7 @@ if (env.BUILD_TAGS_LATEST && env.BUILD_TAGS_LATEST != "") {
         dpdkSource.add([it, 'latest'])
     }
 }
-if (env.BUILD_TAGS_STABLE && env.BUILD_TAGS_STABLE != "") {
+if (env.BUILD_TAGS_STABLE && env.BUILD_TAGS_STABLE != "" && env.BUILD_TAGS_STABLE =~ dpdkVersionPattern) {
     env.BUILD_TAGS_STABLE.eachLine {
         dpdkSource.add([it, 'stable'])
     }

--- a/scripts/package_building/check_latest_tags.sh
+++ b/scripts/package_building/check_latest_tags.sh
@@ -20,7 +20,11 @@ function get_latest_versions {
 
     pushd "./${repo_name}"
     # Get latest 2 versions
-    ver="$(git tag | sort --version-sort --reverse | grep -E "^v[0-9]{1,3}\.[0-9]{1,3}$" -m2)"
+    if [[ $kernel_tree =~ "dpdk" ]];then
+        ver="$(git tag | sort --version-sort --reverse | grep -E "^v([1][8-9]\.[0-9]{1,3}|[2-9][0-9]\.[0-9]{1,3})$" -m2)"
+    else
+        ver="$(git tag | sort --version-sort --reverse | grep -E "^v[0-9]{1,3}\.[0-9]{1,3}$" -m2)"
+    fi
 
     versions=""
     for i in $ver;do

--- a/scripts/package_building/check_latest_tags.sh
+++ b/scripts/package_building/check_latest_tags.sh
@@ -20,11 +20,7 @@ function get_latest_versions {
 
     pushd "./${repo_name}"
     # Get latest 2 versions
-    if [[ $kernel_tree =~ "dpdk" ]];then
-        ver="$(git tag | sort --version-sort --reverse | grep -E "^v([1][8-9]\.[0-9]{1,3}|[2-9][0-9]\.[0-9]{1,3})$" -m2)"
-    else
-        ver="$(git tag | sort --version-sort --reverse | grep -E "^v[0-9]{1,3}\.[0-9]{1,3}$" -m2)"
-    fi
+    ver="$(git tag | sort --version-sort --reverse | grep -E "^v[0-9]{1,3}\.[0-9]{1,3}$" -m2)"
 
     versions=""
     for i in $ver;do


### PR DESCRIPTION
Updated check_latest_tags.sh script to check DPDK releases that are higher than 17.11, which is no longer supported by Azure.

As this script is run by pipeline, what will changes result into is shown in the screenshot below. 

![dpdk-version-check](https://user-images.githubusercontent.com/13867573/66174865-f3c03700-e60b-11e9-8054-72c99201c244.png)
