### PR TITLE
check_latest_tags: added hourly check for tags

### DIFF
--- a/linux_pipeline/Jenkinsfile_dpdk_pipeline
+++ b/linux_pipeline/Jenkinsfile_dpdk_pipeline
@@ -144,7 +144,8 @@ if (!DPDK_SOURCE || DPDK_SOURCE == "") {
                         --work_dir "./" \\
                         --kernel_tree "$DPDK_REMOTE_URL" \\
                         --results "./latest_tags.txt" \\
-                        --exclude_versions "False"
+                        --exclude_versions "False" \\
+                        --checks "hourly"
                 '''
                 sh '''
                     #!/bin/bash
@@ -152,7 +153,8 @@ if (!DPDK_SOURCE || DPDK_SOURCE == "") {
                         --work_dir "./" \\
                         --kernel_tree "$DPDK_STABLE_REMOTE_URL" \\
                         --results "./stable_tags.txt" \\
-                        --exclude_versions "False"
+                        --exclude_versions "False" \\
+                        --checks "hourly"
                 '''
                 env.BUILD_TAGS_LATEST = readFile ("latest_tags.txt")
                 env.BUILD_TAGS_STABLE = readFile ("stable_tags.txt")


### PR DESCRIPTION
Added hourly check to the check_latest_tags so that the pipeline can check for new tags every hour and we can get results quicker.

```
abmarath@MININT-VQUSADS:~/lis-pipeline/scripts/package_building$ bash ./check_latest_tags.sh --work_dir "~/" --kernel_tree "git://git.dpdk.org/dpdk-stable" --results "./stable_tags.txt" --exclude_versions "False"
+ main --work_dir '~/' --kernel_tree git://git.dpdk.org/dpdk-stable --results ./stable_tags.txt --exclude_versions False
+ EXCLUDE_VERSIONS=True
+ true
+ case "$1" in
+ WORK_DIR='~/'
+ shift 2
+ true
+ case "$1" in
+ KERNEL_TREE=git://git.dpdk.org/dpdk-stable
+ shift 2
+ true
+ case "$1" in
++ readlink -ef ./stable_tags.txt
+ RESULTS_PATH=/home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt
+ shift 2
+ true
+ case "$1" in
+ EXCLUDE_VERSIONS=False
+ shift 2
+ true
+ case "$1" in
+ break
+ [[ ! -n ~/ ]]
+ [[ ! -n git://git.dpdk.org/dpdk-stable ]]
+ [[ ! -n /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt ]]
+ [[ ! -d ~/ ]]
+ [[ -e /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt ]]
+ rm /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt
+ touch /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt
++ basename git://git.dpdk.org/dpdk-stable
+ REPO_NAME=dpdk-stable
+ REPO_NAME=dpdk-stable
+ pushd '~/'
~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ resolve_tree_state dpdk-stable git://git.dpdk.org/dpdk-stable
+ repo_name=dpdk-stable
+ kernel_tree=git://git.dpdk.org/dpdk-stable
+ [[ -d dpdk-stable ]]
+ pushd ./dpdk-stable
~/lis-pipeline/scripts/package_building/~/dpdk-stable ~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ git pull
Already up to date.
+ popd
~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ [[ False == \T\r\u\e ]]
+ get_latest_commits dpdk-stable '' /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt ''
+ repo_name=dpdk-stable
+ versions=
+ results_path=/home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt
+ check=
+ pushd ./dpdk-stable
~/lis-pipeline/scripts/package_building/~/dpdk-stable ~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ [[ '' == \h\o\u\r\l\y ]]
++ date +%b -d yesterday
+ current_month=Jan
++ date +%d -d yesterday
++ sed 's/^0*//'
+ current_day=14
++ date +%Y -d yesterday
+ current_year=2020
++ git tag -l '--format=%(refname) %(taggerdate)'
++ grep 'Jan 14'
++ grep 2020
+ full_tags='refs/tags/v18.11.6-rc2 Tue Jan 14 13:57:19 2020 +0000'
+ [[ -n '' ]]
++ echo 'refs/tags/v18.11.6-rc2 Tue Jan 14 13:57:19 2020 +0000'
++ sed 's/ .*//'
+ tags=refs/tags/v18.11.6-rc2
+ commits=
+ for tag in $tags
+ commits+='refs/tags/v18.11.6-rc2;'
+ [[ -n refs/tags/v18.11.6-rc2; ]]
+ echo refs/tags/v18.11.6-rc2
+ popd
~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ popd
~/lis-pipeline/scripts/package_building
abmarath@MININT-VQUSADS:~/lis-pipeline/scripts/package_building$ bash ./check_latest_tags.sh --work_dir "~/" --kernel_tree "git://git.dpdk.org/dpdk-stable" --results "./stable_tags.txt" --exclude_versions "False" --checks "hourly"
+ main --work_dir '~/' --kernel_tree git://git.dpdk.org/dpdk-stable --results ./stable_tags.txt --exclude_versions False --checks hourly
+ EXCLUDE_VERSIONS=True
+ true
+ case "$1" in
+ WORK_DIR='~/'
+ shift 2
+ true
+ case "$1" in
+ KERNEL_TREE=git://git.dpdk.org/dpdk-stable
+ shift 2
+ true
+ case "$1" in
++ readlink -ef ./stable_tags.txt
+ RESULTS_PATH=/home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt
+ shift 2
+ true
+ case "$1" in
+ EXCLUDE_VERSIONS=False
+ shift 2
+ true
+ case "$1" in
+ CHECKS=hourly
+ shift 2
+ true
+ case "$1" in
+ break
+ [[ ! -n ~/ ]]
+ [[ ! -n git://git.dpdk.org/dpdk-stable ]]
+ [[ ! -n /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt ]]
+ [[ ! -d ~/ ]]
+ [[ -e /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt ]]
+ rm /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt
+ touch /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt
++ basename git://git.dpdk.org/dpdk-stable
+ REPO_NAME=dpdk-stable
+ REPO_NAME=dpdk-stable
+ pushd '~/'
~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ resolve_tree_state dpdk-stable git://git.dpdk.org/dpdk-stable
+ repo_name=dpdk-stable
+ kernel_tree=git://git.dpdk.org/dpdk-stable
+ [[ -d dpdk-stable ]]
+ pushd ./dpdk-stable
~/lis-pipeline/scripts/package_building/~/dpdk-stable ~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ git pull
Already up to date.
+ popd
~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ [[ False == \T\r\u\e ]]
+ get_latest_commits dpdk-stable '' /home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt hourly
+ repo_name=dpdk-stable
+ versions=
+ results_path=/home/abmarath/lis-pipeline/scripts/package_building/stable_tags.txt
+ check=hourly
+ pushd ./dpdk-stable
~/lis-pipeline/scripts/package_building/~/dpdk-stable ~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ [[ hourly == \h\o\u\r\l\y ]]
++ date +%b
+ current_month=Jan
++ date +%d
++ sed 's/^0*//'
+ current_day=15
++ date +%Y
+ current_year=2020
++ date -d '-70 minutes' +%H:%M:%S
+ last_hour=12:45:26
++ git tag -l '--format=%(refname) %(taggerdate)'
++ grep 'Jan 15'
++ grep 2020
++ awk '$5 > "${last_hour}"'
+ full_tags=
+ [[ -n '' ]]
++ echo ''
++ sed 's/ .*//'
+ tags=
+ commits=
+ [[ -n '' ]]
+ popd
~/lis-pipeline/scripts/package_building/~ ~/lis-pipeline/scripts/package_building
+ popd
~/lis-pipeline/scripts/package_building
```