### PR TITLE
gawk is required in debian/rules

### DIFF
--- a/scripts/package_building/build_artifacts.sh
+++ b/scripts/package_building/build_artifacts.sh
@@ -42,7 +42,7 @@ function install_deps_debian {
     devscripts build-essential lintian debhelper git wget bc fakeroot crudini flex bison  \
     asciidoc libdw-dev systemtap-sdt-dev libunwind-dev libaudit-dev libslang2-dev \
     libperl-dev python-dev binutils-dev libiberty-dev liblzma-dev libnuma-dev openjdk-8-jdk \
-    libbabeltrace-ctf-dev libbabeltrace-dev rename)
+    libbabeltrace-ctf-dev libbabeltrace-dev rename gawk)
     DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${deb_packages[@]}
 }
 


### PR DESCRIPTION
The KERNEL_COMMIT assignment in debian/rules requires gawk for text
parsing but gawk may not be installed prior to the kernel build. Without
gawk installed, the linux-image-azure package will Depend on an invalid
package name, such as "linux-image-5.4.40-".

Signed-off-by: Tyler Hicks <tyhicks@linux.microsoft.com>