### PR TITLE
package-building: Include the kernel version in the metapackage filename

### DIFF
--- a/scripts/package_building/kernel_metapackages/linux-latest/debian/rules
+++ b/scripts/package_building/kernel_metapackages/linux-latest/debian/rules
@@ -91,7 +91,7 @@ binary-arch: debian/control install
 	dh_installdeb -s
 	dh_gencontrol -s -- $(gencontrol_flags)
 	dh_md5sums -s
-	dh_builddeb -s --destdir="${META_DESTINATION}" --filename="package"
+	dh_builddeb -s --destdir="${META_DESTINATION}"
 
 binary: binary-indep binary-arch
 


### PR DESCRIPTION
Include the kernel version string in the filenames of the kernel
metapackages. Debian package archives and debootstrap expect the deb
filenames to be versioned.

With this change, we see the following differences in the filenames of
the metapackage debs:

linux-headers-azure.deb => linux-image-azure_5.4.58-59a59018719e_amd64.deb
linux-image-azure-dbg.deb => linux-headers-azure_5.4.58-59a59018719e_amd64.deb
linux-image-azure.deb => linux-image-azure-dbg_5.4.58-59a59018719e_amd64.deb

Signed-off-by: Tyler Hicks <tyhicks@linux.microsoft.com>